### PR TITLE
Change unwrap to expect in index overloads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1105,12 +1105,12 @@ impl<T> ops::Index<Index> for Arena<T> {
     type Output = T;
 
     fn index(&self, index: Index) -> &Self::Output {
-        self.get(index).unwrap()
+        self.get(index).expect("No element at index")
     }
 }
 
 impl<T> ops::IndexMut<Index> for Arena<T> {
     fn index_mut(&mut self, index: Index) -> &mut Self::Output {
-        self.get_mut(index).unwrap()
+        self.get_mut(index).expect("No element at index")
     }
 }


### PR DESCRIPTION
Just bugged me that those just panic with very little indication of what goes on. Feels like it should be a little more helpful than that (since it can be). I'm really not picky on what the error message says, I'm happy to change it.