### PR TITLE
Change generation type to `NonZeroU64`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,10 +162,10 @@ cfg_if! {
 
 use core::cmp;
 use core::iter::{self, Extend, FromIterator, FusedIterator};
+use core::num::NonZeroU64;
 use core::mem;
 use core::ops;
 use core::slice;
-use core::num::NonZeroU64;
 
 #[cfg(feature = "serde")]
 mod serde_impl;

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -3,6 +3,7 @@ use core::cmp;
 use core::fmt;
 use core::iter;
 use core::marker::PhantomData;
+use core::num::NonZeroU64;
 use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
 use serde::ser::{Serialize, Serializer};
 
@@ -85,8 +86,8 @@ where
         let init_cap = access.size_hint().unwrap_or(DEFAULT_CAPACITY);
         let mut items = Vec::with_capacity(init_cap);
 
-        let mut generation = 0;
-        while let Some(element) = access.next_element::<Option<(u64, T)>>()? {
+        let mut generation = NonZeroU64::new(1).expect("1 as NonZeroU64");
+        while let Some(element) = access.next_element::<Option<(NonZeroU64, T)>>()? {
             let item = match element {
                 Some((gen, value)) => {
                     generation = cmp::max(generation, gen);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -128,7 +128,7 @@ fn fully_occupied_arena_can_be_serialized_and_deserialized() {
         tokens.extend(&[
             Token::Some,
             Token::Tuple { len: 2 },
-            Token::U64(0),
+            Token::U64(1),
             Token::U64((i * i) as u64),
             Token::TupleEnd,
         ]);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -137,6 +137,13 @@ fn fully_occupied_arena_can_be_serialized_and_deserialized() {
     assert_tokens(&arena, &tokens);
 }
 
+#[test]
+fn zero_generation_index_cannot_be_deserialized() {
+    let fake_index = (0, 0);
+    let serialized_fake_index = bincode::serialize(&fake_index).expect("fake_index must be serialized");
+    assert!(bincode::deserialize::<Index>(&serialized_fake_index).is_err());
+}
+
 /// Arena wrapper struct for comparing two arenas
 ///
 /// `serde_test::assert_tokens` requires the value implements `PartialEq`,


### PR DESCRIPTION
From the [docs](https://doc.rust-lang.org/nightly/std/num/struct.NonZeroU64.html): [A `NonZeroU64` is] an integer that is known not to equal zero. This enables some memory layout optimization. For example, `Option<NonZeroU64>` is the same size as `u64`.

I replaced `generation: u64` with `NonZeroU64` (initializing it to 1 rather than 0). [This example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=764d7db69f547b3bef75164bfb978660) shows that `Index` takes 16 bytes of memory, and `Option<Index>` currently takes 24 bytes, but with this optimization it would take 16 bytes like a plain `Index`.

I run the benchmarks and the results are _almost_ the same. There may be a small regression (but it could also just be a random fluctation) caused by the fact that incrementing a `NonZeroU64` by 1 requires converting it to a `u64` and back. If `NonZeroU64` gets better support in the standard library, that may be optimized further.

Still, memory optimization is significative. I myself may need to store a large amount of `Option<Index>` and I belive it's a rather common use-case, so I think it would be worth it.