### PR TITLE
Added possibility to make the Index opaque

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,20 @@ pub struct Index {
     generation: u64,
 }
 
+impl Index {
+    /// Create a new `Index` from its raw parts.
+    /// This function is unsafe because generates a wrong `Index` and use it cause panics.
+    pub fn from_raw_parts(index: usize, generation: u64) -> Index {
+        Index { index, generation }
+    }
+
+    /// Returns the raw parts of the `Index`.
+    /// This function is useful to make this `Index` opaque.
+    pub fn into_raw_parts(self) -> (usize, u64) {
+        (self.index, self.generation)
+    }
+}
+
 const DEFAULT_CAPACITY: usize = 4;
 
 impl<T> Arena<T> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,6 +3,15 @@ use generational_arena::Arena;
 use std::collections::BTreeSet;
 
 #[test]
+fn can_decompose_index() {
+    let mut arena = Arena::with_capacity(1);
+    let i = arena.try_insert(42).unwrap();
+    let(k, g) = i.into_raw_parts();
+    let generated_i = generational_arena::Index::from_raw_parts(k, g);
+    assert_eq!(arena[generated_i], 42);
+}
+
+#[test]
 fn can_get_live_value() {
     let mut arena = Arena::with_capacity(1);
     let i = arena.try_insert(42).unwrap();


### PR DESCRIPTION
Fixes #21 

This PR allows to create a "really customizable" opaque object from an `Index`.

The use case is the following, I've an interface trait (that is provided by crate that I don't own) which provides some API with an opaque ID. I need to construct this Opaque ID from the `Index`.