### PR TITLE
give a &mut T instead of &T to Arena.retain 's closure parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,9 +446,9 @@ impl<T> Arena<T> {
     /// assert_eq!(crew_members.next(), Some("Alexander Smollett"));
     /// assert!(crew_members.next().is_none());
     /// ```
-    pub fn retain(&mut self, mut predicate: impl FnMut(Index, &T) -> bool) {
+    pub fn retain(&mut self, mut predicate: impl FnMut(Index, &mut T) -> bool) {
         for i in 0..self.len {
-            let remove = match &self.items[i] {
+            let remove = match &mut self.items[i] {
                 Entry::Occupied { generation, value } => {
                     let index = Index {
                         index: i,


### PR DESCRIPTION
If you look at the std, the signature for retain looks like this `pub fn retain<F>(&mut self, f: F) where F: FnMut(&K, &mut V) -> bool`, while in generational-arena, the signature looks like `retain(&mut self, predicate: impl FnMut(Index, &T) -> bool)`. The difference is that the predicate gives a `&mut T` in the stdlib while a `&T` in this crate.

This PR changes the behavior of retain to give the closure a `&mut T` signature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fitzgen/generational-arena/25)
<!-- Reviewable:end -->
