### PR TITLE
Add Arena.get_unknown_gen{,_mut}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,46 +543,6 @@ impl<T> Arena<T> {
         }
     }
 
-    /// Given a i of `usize` without generation, get a shared reference
-    /// to the element and the matching `Index` of the entry behind `i`.
-    ///
-    /// This method is useful when you know there might be an element at the
-    /// position i, but don't know its generation or precise Index.
-    ///
-    /// Use cases include using indexing such as Hierarchical BitMap Indexing or
-    /// other kinds of bit-efficient indexing.
-    ///
-    /// You should use the `get` method most of the time.
-    pub fn get_unknown_gen(&self, i: usize) -> Option<(&T, Index)> {
-        match self.items.get(i) {
-            Some(Entry::Occupied {
-                generation,
-                value,
-            }) => Some((value, Index { generation: *generation, index: i})),
-            _ => None,
-        }
-    }
-
-    /// Given a i of `usize` without generation, get an exclusive reference
-    /// to the element and the matching `Index` of the entry behind `i`.
-    ///
-    /// This method is useful when you know there might be an element at the
-    /// position i, but don't know its generation or precise Index.
-    ///
-    /// Use cases include using indexing such as Hierarchical BitMap Indexing or
-    /// other kinds of bit-efficient indexing.
-    ///
-    /// You should use the `get_mut` method most of the time.
-    pub fn get_unknown_gen_mut(&mut self, i: usize) -> Option<(&mut T, Index)> {
-        match self.items.get_mut(i) {
-            Some(Entry::Occupied {
-                generation,
-                value,
-            }) => Some((value, Index { generation: *generation, index: i})),
-            _ => None,
-        }
-    }
-
     /// Get a pair of exclusive references to the elements at index `i1` and `i2` if it is in the
     /// arena.
     ///
@@ -848,6 +808,46 @@ impl<T> Arena<T> {
     pub fn drain(&mut self) -> Drain<T> {
         Drain {
             inner: self.items.drain(..).enumerate(),
+        }
+    }
+
+    /// Given a i of `usize` without generation, get a shared reference
+    /// to the element and the matching `Index` of the entry behind `i`.
+    ///
+    /// This method is useful when you know there might be an element at the
+    /// position i, but don't know its generation or precise Index.
+    ///
+    /// Use cases include using indexing such as Hierarchical BitMap Indexing or
+    /// other kinds of bit-efficient indexing.
+    ///
+    /// You should use the `get` method most of the time.
+    pub fn get_unknown_gen(&self, i: usize) -> Option<(&T, Index)> {
+        match self.items.get(i) {
+            Some(Entry::Occupied {
+                generation,
+                value,
+            }) => Some((value, Index { generation: *generation, index: i})),
+            _ => None,
+        }
+    }
+
+    /// Given a i of `usize` without generation, get an exclusive reference
+    /// to the element and the matching `Index` of the entry behind `i`.
+    ///
+    /// This method is useful when you know there might be an element at the
+    /// position i, but don't know its generation or precise Index.
+    ///
+    /// Use cases include using indexing such as Hierarchical BitMap Indexing or
+    /// other kinds of bit-efficient indexing.
+    ///
+    /// You should use the `get_mut` method most of the time.
+    pub fn get_unknown_gen_mut(&mut self, i: usize) -> Option<(&mut T, Index)> {
+        match self.items.get_mut(i) {
+            Some(Entry::Occupied {
+                generation,
+                value,
+            }) => Some((value, Index { generation: *generation, index: i})),
+            _ => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,6 +543,46 @@ impl<T> Arena<T> {
         }
     }
 
+    /// Given a i of `usize` without generation, get a shared reference
+    /// to the element and the matching `Index` of the entry behind `i`.
+    ///
+    /// This method is useful when you know there might be an element at the
+    /// position i, but don't know its generation or precise Index.
+    ///
+    /// Use cases include using indexing such as Hierarchical BitMap Indexing or
+    /// other kinds of bit-efficient indexing.
+    ///
+    /// You should use the `get` method most of the time.
+    pub fn get_unknown_gen(&self, i: usize) -> Option<(&T, Index)> {
+        match self.items.get(i) {
+            Some(Entry::Occupied {
+                generation,
+                value,
+            }) => Some((value, Index { generation: *generation, index: i})),
+            _ => None,
+        }
+    }
+
+    /// Given a i of `usize` without generation, get an exclusive reference
+    /// to the element and the matching `Index` of the entry behind `i`.
+    ///
+    /// This method is useful when you know there might be an element at the
+    /// position i, but don't know its generation or precise Index.
+    ///
+    /// Use cases include using indexing such as Hierarchical BitMap Indexing or
+    /// other kinds of bit-efficient indexing.
+    ///
+    /// You should use the `get_mut` method most of the time.
+    pub fn get_unknown_gen_mut(&mut self, i: usize) -> Option<(&mut T, Index)> {
+        match self.items.get_mut(i) {
+            Some(Entry::Occupied {
+                generation,
+                value,
+            }) => Some((value, Index { generation: *generation, index: i})),
+            _ => None,
+        }
+    }
+
     /// Get a pair of exclusive references to the elements at index `i1` and `i2` if it is in the
     /// arena.
     ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -88,6 +88,46 @@ fn get2_mut() {
 }
 
 #[test]
+fn get_unknown_gen() {
+    let mut arena = Arena::new();
+    let idx = arena.insert(5);
+
+    let i = idx.into_raw_parts().0;
+
+    if let Some((el, id)) = arena.get_unknown_gen(i) {
+        assert_eq!(id, idx);
+        assert_eq!(*el, 5);
+    } else {
+        panic!("element at index {} (without generation) should exist at this point", i);
+    }
+    arena.remove(idx);
+    if let Some((_, _)) = arena.get_unknown_gen(i) {
+        panic!("element at index {} (without generation) should not exist at this point", i);
+    }
+}
+
+#[test]
+fn get_unknown_gen_mut() {
+    let mut arena = Arena::new();
+    let idx = arena.insert(5);
+
+    let i = idx.into_raw_parts().0;
+
+    if let Some((el, id)) = arena.get_unknown_gen_mut(i) {
+        assert_eq!(id, idx);
+        assert_eq!(*el, 5);
+        *el += 1;
+    } else {
+        panic!("element at index {} (without generation) should exist at this point", i);
+    }
+    assert_eq!(arena.get_mut(idx).cloned(), Some(6));
+    arena.remove(idx);
+    if let Some((_, _)) = arena.get_unknown_gen_mut(i) {
+        panic!("element at index {} (without generation) should not exist at this point", i);
+    }
+}
+
+#[test]
 fn get2_mut_with_same_index_but_different_generation() {
     let mut arena = Arena::with_capacity(2);
     let idx1 = arena.insert(0);


### PR DESCRIPTION
Added 2 methods to get an element without knowing its generation. It's useful mostly for quick indexing via other methods, such as with the crate [hibitset](https://docs.rs/hibitset) or other kinds of bitmaps.

You can only store indexes directly without other info with bitsets, and most of the time you have a wrapper around `Arena` and `BitSet` to make sure the index is always up to date.

Other than that, the method won't get much use, so I skipped the example and made it clear that it shouldn't be used in a normal use case.

I'm hesitating with the method names though, if you have better ideas I'm all ears.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fitzgen/generational-arena/26)
<!-- Reviewable:end -->
