### PR TITLE
Fix Arena::retain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,7 @@ impl<T> Arena<T> {
     /// assert!(crew_members.next().is_none());
     /// ```
     pub fn retain(&mut self, mut predicate: impl FnMut(Index, &mut T) -> bool) {
-        for i in 0..self.len {
+        for i in 0..self.capacity() {
             let remove = match &mut self.items[i] {
                 Entry::Occupied { generation, value } => {
                     let index = Index {

--- a/tests/quickchecks.rs
+++ b/tests/quickchecks.rs
@@ -160,3 +160,36 @@ quickcheck! {
         arena.into_iter().collect::<BTreeSet<_>>() == elems
     }
 }
+
+quickcheck! {
+    fn retain(elems: Vec<bool>) -> () {
+        let mut arena = Arena::new();
+        let mut live_indices = vec![];
+        let mut dead_indices = vec![];
+
+        for elem in elems {
+            let idx = arena.insert(elem);
+            if elem {
+                live_indices.push(idx);
+            } else {
+                dead_indices.push(idx);
+            }
+        }
+
+        arena.retain(|_, &mut b| b);
+        
+        for live in live_indices.iter().cloned() {
+            assert!(arena.contains(live));
+        }
+
+        for dead in dead_indices.iter().cloned() {
+            assert!(!arena.contains(dead));
+        }
+
+        arena.retain(|_, &mut b| !b);
+
+        for live in live_indices.iter().cloned() {
+            assert!(!arena.contains(live));
+        }
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -230,3 +230,30 @@ fn clear() {
     assert_eq!(arena.capacity(), 4);
     assert_eq!(arena.len(), 0);
 }
+
+#[test]
+fn retain() {
+    let mut arena = Arena::with_capacity(4);
+    let index = arena.insert(2);
+    arena.insert(1);
+    arena.insert(4);
+    arena.insert(3);
+
+    assert_eq!(arena.len(), 4);
+
+    arena.retain(|_, n| *n < 4);
+
+    assert_eq!(arena.len(), 3);
+    assert!(arena.iter().all(|(_, n)| *n < 4));
+
+    arena.retain(|_, n| *n < 3);
+
+    assert_eq!(arena.len(), 2);
+    assert!(arena.iter().all(|(_, n)| *n < 3));
+    assert!(arena.contains(index));
+
+    arena.retain(|i, _| i != index);
+
+    assert_eq!(arena.len(), 1);
+    assert!(!arena.contains(index));
+}


### PR DESCRIPTION
`retain` was iterating over `self.len` and not `self.capacity()` causing it not visit entries when there are free slots in the middle of the Vec.