### PR TITLE
insert_with and try_insert_with constructors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,33 @@ impl<T> Arena<T> {
         }
     }
 
-    /// TODO DOCS
+    /// Attempts to insert the value returned by `create` into the arena using existing capacity.
+    /// `create` is called with the new value's associated index, allowing values that know their own index.
+    ///
+    /// This method will never allocate new capacity in the arena.
+    ///
+    /// If insertion succeeds, then the new index is returned. If
+    /// insertion fails, then `Err(create)` is returned to give ownership of
+    /// `create` back to the caller.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use generational_arena::{Arena, Index};
+    ///
+    /// let mut arena = Arena::new();
+    ///
+    /// match arena.try_insert_with(|idx| (42, idx)) {
+    ///     Ok(idx) => {
+    ///         // Insertion succeeded.
+    ///         assert_eq!(arena[idx].0, 42);
+    ///         assert_eq!(arena[idx].1, idx);
+    ///     }
+    ///     Err(x) => {
+    ///         // Insertion failed.
+    ///     }
+    /// };
+    /// ```
     #[inline]
     pub fn try_insert_with<F: FnOnce(Index) -> T>(&mut self, create: F) -> Result<Index, F> {
         match self.try_alloc_next_index() {
@@ -410,7 +436,22 @@ impl<T> Arena<T> {
         }
     }
 
-    /// TODO DOCS
+    /// Insert the value returned by `create` into the arena, allocating more capacity if necessary.
+    /// `create` is called with the new value's associated index, allowing values that know their own index.
+    ///
+    /// The new value's associated index in the arena is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use generational_arena::{Arena, Index};
+    ///
+    /// let mut arena = Arena::new();
+    ///
+    /// let idx = arena.insert_with(|idx| (42, idx));
+    /// assert_eq!(arena[idx].0, 42);
+    /// assert_eq!(arena[idx].1, idx);
+    /// ```
     #[inline]
     pub fn insert_with(&mut self, create: impl FnOnce(Index) -> T) -> Index {
         match self.try_insert_with(create) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,23 +343,48 @@ impl<T> Arena<T> {
     /// ```
     #[inline]
     pub fn try_insert(&mut self, value: T) -> Result<Index, T> {
-        match self.free_list_head {
+        match self.try_alloc_next_index() {
             None => Err(value),
+            Some(index) => {
+                self.items[index.index] = Entry::Occupied {
+                    generation: self.generation,
+                    value,
+                };
+                Ok(index)
+            },
+        }
+    }
+
+    /// TODO DOCS
+    #[inline]
+    pub fn try_insert_with<F: FnOnce(Index) -> T>(&mut self, create: F) -> Result<Index, F> {
+        match self.try_alloc_next_index() {
+            None => Err(create),
+            Some(index) => {
+                self.items[index.index] = Entry::Occupied {
+                    generation: self.generation,
+                    value: create(index),
+                };
+                Ok(index)
+            },
+        }
+    }
+
+    #[inline]
+    fn try_alloc_next_index(&mut self) -> Option<Index> {
+        match self.free_list_head {
+            None => None,
             Some(i) => match self.items[i] {
                 Entry::Occupied { .. } => panic!("corrupt free list"),
                 Entry::Free { next_free } => {
                     self.free_list_head = next_free;
                     self.len += 1;
-                    self.items[i] = Entry::Occupied {
-                        generation: self.generation,
-                        value,
-                    };
-                    Ok(Index {
+                    Some(Index {
                         index: i,
                         generation: self.generation,
                     })
                 }
-            },
+            }
         }
     }
 
@@ -385,11 +410,29 @@ impl<T> Arena<T> {
         }
     }
 
+    /// TODO DOCS
+    #[inline]
+    pub fn insert_with(&mut self, create: impl FnOnce(Index) -> T) -> Index {
+        match self.try_insert_with(create) {
+            Ok(i) => i,
+            Err(create) => self.insert_with_slow_path(create),
+        }
+    }
+
     #[inline(never)]
     fn insert_slow_path(&mut self, value: T) -> Index {
         let len = self.items.len();
         self.reserve(len);
         self.try_insert(value)
+            .map_err(|_| ())
+            .expect("inserting will always succeed after reserving additional space")
+    }
+
+    #[inline(never)]
+    fn insert_with_slow_path(&mut self, create: impl FnOnce(Index) -> T) -> Index {
+        let len = self.items.len();
+        self.reserve(len);
+        self.try_insert_with(create)
             .map_err(|_| ())
             .expect("inserting will always succeed after reserving additional space")
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -46,6 +46,14 @@ fn try_insert_when_full() {
 }
 
 #[test]
+fn try_insert_with_when_full() {
+    let mut arena = Arena::with_capacity(1);
+    let first_index = arena.try_insert_with(|_| 42).ok().unwrap();
+    let returned_fn = arena.try_insert_with(|_| 42).unwrap_err();
+    assert_eq!(returned_fn(first_index), 42);
+}
+
+#[test]
 fn insert_many_and_cause_doubling() {
     let mut arena = Arena::new();
     let indices: Vec<_> = (0..1000).map(|i| arena.insert(i * i)).collect();
@@ -53,6 +61,34 @@ fn insert_many_and_cause_doubling() {
         assert_eq!(arena.remove(idx).unwrap(), i * i);
         assert!(!arena.contains(idx));
     }
+}
+
+#[test]
+fn insert_with_indicies_match() {
+    let mut arena = Arena::new();
+    let a = arena.insert_with(|idx| (40, idx));
+    let b = arena.insert_with(|idx| (41, idx));
+    let c = arena.insert_with(|idx| (42, idx));
+    assert_eq!(arena[a].0, 40);
+    assert_eq!(arena[b].0, 41);
+    assert_eq!(arena[c].0, 42);
+    assert_eq!(arena[a].1, a);
+    assert_eq!(arena[b].1, b);
+    assert_eq!(arena[c].1, c);
+}
+
+#[test]
+fn try_insert_with_indicies_match() {
+    let mut arena = Arena::with_capacity(3);
+    let a = arena.try_insert_with(|idx| (40, idx)).ok().unwrap();
+    let b = arena.try_insert_with(|idx| (41, idx)).ok().unwrap();
+    let c = arena.try_insert_with(|idx| (42, idx)).ok().unwrap();
+    assert_eq!(arena[a].0, 40);
+    assert_eq!(arena[b].0, 41);
+    assert_eq!(arena[c].0, 42);
+    assert_eq!(arena[a].1, a);
+    assert_eq!(arena[b].1, b);
+    assert_eq!(arena[c].1, c);
 }
 
 #[test]


### PR DESCRIPTION
Allows values to know their own index, fixes #33. Happy to add more tests or change the impl around, just let me know.

Haven't run benchmarks to figure out if there's a performance degradation from adding `try_alloc_next_index`; could manually inline that code in both functions but it seemed like slightly tricky code that should be deduplicated.

(Sorry if I sniped your issue @jannickj, but it didn't look like you had started implementing yet?)