### PR TITLE
Add `shrink_to_fit`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ impl<T> Arena<T> {
                     value,
                 };
                 Ok(index)
-            },
+            }
         }
     }
 
@@ -381,7 +381,7 @@ impl<T> Arena<T> {
                     value: create(index),
                 };
                 Ok(index)
-            },
+            }
         }
     }
 
@@ -399,7 +399,7 @@ impl<T> Arena<T> {
                         generation: self.generation,
                     })
                 }
-            }
+            },
         }
     }
 
@@ -492,14 +492,19 @@ impl<T> Arena<T> {
             Entry::Occupied { generation, .. } if i.generation == generation => {
                 let entry = mem::replace(
                     &mut self.items[i.index],
-                    Entry::Free { next_free: self.free_list_head },
+                    Entry::Free {
+                        next_free: self.free_list_head,
+                    },
                 );
                 self.generation += 1;
                 self.free_list_head = Some(i.index);
                 self.len -= 1;
 
                 match entry {
-                    Entry::Occupied { generation: _, value } => Some(value),
+                    Entry::Occupied {
+                        generation: _,
+                        value,
+                    } => Some(value),
                     _ => unreachable!(),
                 }
             }
@@ -587,10 +592,9 @@ impl<T> Arena<T> {
     /// ```
     pub fn get(&self, i: Index) -> Option<&T> {
         match self.items.get(i.index) {
-            Some(Entry::Occupied {
-                generation,
-                value,
-            }) if *generation == i.generation => Some(value),
+            Some(Entry::Occupied { generation, value }) if *generation == i.generation => {
+                Some(value)
+            }
             _ => None,
         }
     }
@@ -614,10 +618,9 @@ impl<T> Arena<T> {
     /// ```
     pub fn get_mut(&mut self, i: Index) -> Option<&mut T> {
         match self.items.get_mut(i.index) {
-            Some(Entry::Occupied {
-                generation,
-                value,
-            }) if *generation == i.generation => Some(value),
+            Some(Entry::Occupied { generation, value }) if *generation == i.generation => {
+                Some(value)
+            }
             _ => None,
         }
     }
@@ -679,18 +682,12 @@ impl<T> Arena<T> {
         };
 
         let item1 = match raw_item1 {
-            Entry::Occupied {
-                generation,
-                value,
-            } if *generation == i1.generation => Some(value),
+            Entry::Occupied { generation, value } if *generation == i1.generation => Some(value),
             _ => None,
         };
 
         let item2 = match raw_item2 {
-            Entry::Occupied {
-                generation,
-                value,
-            } if *generation == i2.generation => Some(value),
+            Entry::Occupied { generation, value } if *generation == i2.generation => Some(value),
             _ => None,
         };
 
@@ -819,7 +816,13 @@ impl<T> Arena<T> {
     /// assert_eq!(arena.capacity(), 5);
     /// ```
     pub fn shrink_to_fit(&mut self) {
-        self.items.truncate(self.items.iter().rposition(|entry| matches!(entry, Entry::Occupied { .. })).map(|n| n + 1).unwrap_or(0));
+        self.items.truncate(
+            self.items
+                .iter()
+                .rposition(|entry| matches!(entry, Entry::Occupied { .. }))
+                .map(|n| n + 1)
+                .unwrap_or(0),
+        );
         self.items.shrink_to_fit();
 
         self.free_list_head = None;
@@ -931,10 +934,13 @@ impl<T> Arena<T> {
     /// You should use the `get` method instead most of the time.
     pub fn get_unknown_gen(&self, i: usize) -> Option<(&T, Index)> {
         match self.items.get(i) {
-            Some(Entry::Occupied {
-                generation,
+            Some(Entry::Occupied { generation, value }) => Some((
                 value,
-            }) => Some((value, Index { generation: *generation, index: i})),
+                Index {
+                    generation: *generation,
+                    index: i,
+                },
+            )),
             _ => None,
         }
     }
@@ -951,10 +957,13 @@ impl<T> Arena<T> {
     /// You should use the `get_mut` method instead most of the time.
     pub fn get_unknown_gen_mut(&mut self, i: usize) -> Option<(&mut T, Index)> {
         match self.items.get_mut(i) {
-            Some(Entry::Occupied {
-                generation,
+            Some(Entry::Occupied { generation, value }) => Some((
                 value,
-            }) => Some((value, Index { generation: *generation, index: i})),
+                Index {
+                    generation: *generation,
+                    index: i,
+                },
+            )),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,19 +300,8 @@ impl<T> Arena<T> {
     /// ```
     pub fn clear(&mut self) {
         self.items.clear();
-
-        let end = self.items.capacity();
-        self.items.extend((0..end).map(|i| {
-            if i == end - 1 {
-                Entry::Free { next_free: None }
-            } else {
-                Entry::Free {
-                    next_free: Some(i + 1),
-                }
-            }
-        }));
-        self.free_list_head = Some(0);
         self.len = 0;
+        self.reserve(self.items.capacity());
     }
 
     /// Attempts to insert `value` into the arena using existing capacity.
@@ -814,6 +803,35 @@ impl<T> Arena<T> {
             }
         }));
         self.free_list_head = Some(start);
+    }
+
+    /// Reduces allocated space to the minimum possible to fit all the elements in the arena.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use generational_arena::Arena;
+    ///
+    /// let mut arena = Arena::new();
+    /// arena.extend([1, 2, 3, 4, 5].iter().copied());
+    /// assert!(arena.capacity() >= 5);
+    /// arena.shrink_to_fit();
+    /// assert_eq!(arena.capacity(), 5);
+    /// ```
+    pub fn shrink_to_fit(&mut self) {
+        self.items.truncate(self.items.iter().rposition(|entry| matches!(entry, Entry::Occupied { .. })).map(|n| n + 1).unwrap_or(0));
+        self.items.shrink_to_fit();
+
+        self.free_list_head = None;
+        for (i, item) in self.items.iter_mut().enumerate() {
+            match item {
+                Entry::Occupied { .. } => (),
+                Entry::Free { next_free } => {
+                    *next_free = self.free_list_head;
+                    self.free_list_head = Some(i);
+                }
+            }
+        }
     }
 
     /// Iterate over shared references to the elements in this arena.

--- a/tests/quickchecks.rs
+++ b/tests/quickchecks.rs
@@ -177,7 +177,7 @@ quickcheck! {
         }
 
         arena.retain(|_, &mut b| b);
-        
+
         for live in live_indices.iter().cloned() {
             assert!(arena.contains(live));
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -293,3 +293,28 @@ fn retain() {
     assert_eq!(arena.len(), 1);
     assert!(!arena.contains(index));
 }
+
+#[test]
+fn shrink_to_fit() {
+    let mut arena = Arena::with_capacity(4);
+
+    arena.extend([1, 2, 3, 4].iter().copied());
+    let five = arena.insert(5);
+    assert_eq!(arena.capacity(), 8);
+
+    arena.shrink_to_fit();
+    assert_eq!(arena.len(), 5);
+    assert_eq!(arena.capacity(), 5);
+
+    arena.insert(6);
+    assert_eq!(arena.capacity(), 10);
+
+    arena.shrink_to_fit();
+    assert_eq!(arena.len(), 6);
+    assert_eq!(arena.capacity(), 6);
+
+    arena.remove(five);
+    arena.shrink_to_fit();
+    assert_eq!(arena.len(), 5);
+    assert_eq!(arena.capacity(), 6);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -134,11 +134,17 @@ fn get_unknown_gen() {
         assert_eq!(id, idx);
         assert_eq!(*el, 5);
     } else {
-        panic!("element at index {} (without generation) should exist at this point", i);
+        panic!(
+            "element at index {} (without generation) should exist at this point",
+            i
+        );
     }
     arena.remove(idx);
     if let Some((_, _)) = arena.get_unknown_gen(i) {
-        panic!("element at index {} (without generation) should not exist at this point", i);
+        panic!(
+            "element at index {} (without generation) should not exist at this point",
+            i
+        );
     }
 }
 
@@ -154,12 +160,18 @@ fn get_unknown_gen_mut() {
         assert_eq!(*el, 5);
         *el += 1;
     } else {
-        panic!("element at index {} (without generation) should exist at this point", i);
+        panic!(
+            "element at index {} (without generation) should exist at this point",
+            i
+        );
     }
     assert_eq!(arena.get_mut(idx).cloned(), Some(6));
     arena.remove(idx);
     if let Some((_, _)) = arena.get_unknown_gen_mut(i) {
-        panic!("element at index {} (without generation) should not exist at this point", i);
+        panic!(
+            "element at index {} (without generation) should not exist at this point",
+            i
+        );
     }
 }
 


### PR DESCRIPTION
Closes #19. I didn't implement `shrink_to` since it is unstable.

I also simplified the implementation of `clear`, since I noticed it was possible; there are a few other minor changes from `rustfmt` too.