### PR TITLE
Fix issue #27, Add test for the issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.102", optional = true, default-features = false }
 quickcheck = "0.9.0"
 criterion = "0.3.0"
 serde_test = "1.0.102"
+serde_yaml = "0.8.13"
 bincode = "1.2.0"
 serde = { version = "1.0.102", default-features = false, features = ["derive"] }
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -101,8 +101,8 @@ where
         }
 
         // items.len() must be same as item.capacity(), so fill the unused elements with Free.
-        if items.len() + 1 < items.capacity() {
-            let add_cap = items.capacity() - (items.len() + 1);
+        if items.len() < items.capacity() {
+            let add_cap = items.capacity() - items.len();
             items.reserve_exact(add_cap);
             items.extend(iter::repeat_with(|| Entry::Free { next_free: None }).take(add_cap));
             debug_assert_eq!(items.len(), items.capacity());

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -9,6 +9,7 @@ extern crate serde_test;
 use generational_arena::{Arena, Index};
 use serde::{Deserialize, Serialize};
 use serde_test::{assert_ser_tokens, Token};
+use std::iter::FromIterator;
 use std::fmt::Debug;
 
 #[test]
@@ -137,6 +138,17 @@ fn fully_occupied_arena_can_be_serialized_and_deserialized() {
     }
     tokens.push(Token::SeqEnd);
     assert_tokens(&arena, &tokens);
+}
+
+#[test]
+fn arena_from_iter_can_be_serialized_and_deserialized_without_panic() {
+
+    let mut vec = vec![0usize];
+    let x = vec.drain(..);
+    let mut arena_in = Arena::from_iter(x);
+
+    let ser = serde_yaml::to_string(&arena_in).unwrap();
+    let arena_out: Arena<usize> = serde_yaml::from_str(&ser).unwrap();
 }
 
 /// Arena wrapper struct for comparing two arenas


### PR DESCRIPTION
Hello 🦀 , this PR makes the following changes

* Add fix for issue #27 . (Resolves #27)
   The fix itself wasn't complex. (`src/serde_impl.rs`)
* Add minimal test for the issue.
   I could also get rid of the test if it's not worth having a new test for the issue.
```rust
#[test]
fn arena_from_iter_can_be_serialized_and_deserialized_without_panic() {

    let mut vec = vec![0usize];
    let x = vec.drain(..);
    let mut arena_in = Arena::from_iter(x);

    let ser = serde_yaml::to_string(&arena_in).unwrap();
    let arena_out: Arena<usize> = serde_yaml::from_str(&ser).unwrap();
}
```
Thank you for reviewing this PR! 👍 