### PR TITLE
Increment generation when Arena::clear() called

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,6 +309,11 @@ impl<T> Arena<T> {
                 }
             }
         }));
+        if !self.is_empty() {
+            // Increment generation, but if there are no elements, do nothing to
+            // avoid unnecessary incrementing generation.
+            self.generation += 1;
+        }
         self.free_list_head = Some(0);
         self.len = 0;
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -268,6 +268,24 @@ fn clear() {
 }
 
 #[test]
+fn clear_gen() {
+    let mut arena = Arena::with_capacity(1);
+    let idx_1 = arena.insert(1);
+    arena.clear();
+    let idx_2 = arena.insert(2);
+    assert_ne!(idx_1, idx_2);
+
+    // If there are no elements, do not increment generation.
+    let mut arena_2 = Arena::with_capacity(1);
+    arena_2.clear();
+    arena_2.clear();
+    arena_2.clear();
+    let idx_1 = arena_2.insert(1);
+    let gen = idx_1.into_raw_parts().1;
+    assert_eq!(gen, 0);
+}
+
+#[test]
 fn retain() {
     let mut arena = Arena::with_capacity(4);
     let index = arena.insert(2);


### PR DESCRIPTION
This fixes the first issue of #30.

> 1. If you add some elements and then use Arena::clear(), this should bump the arena's generation, but it doesn't. So if you add some more elements afterwards, you can have a new element with the exact same Index as one of the cleared elements, and so you can access it with a stale Index, which is wrong.

It seems the issues on Arena::drain() are more complicated, so ~~I plan to do it as a separate PR.~~ EDIT: filed #45